### PR TITLE
fix problem with data-color 

### DIFF
--- a/lib/bootstrap-colorpicker.js
+++ b/lib/bootstrap-colorpicker.js
@@ -197,7 +197,7 @@
     },
 
     update: function(){
-      this.color = new Color(this.isInput ? this.element.prop('value') : this.element.attr('colorcode'));
+      this.color = new Color(this.isInput ? this.element.prop('value') : this.element.attr('data-color'));
       this.picker.find('i')
         .eq(0).css({left: this.color.value.s*100, top: 100 - this.color.value.b*100}).end()
         .eq(1).css('top', 100 * (1 - this.color.value.h)).end()


### PR DESCRIPTION
Value from `data-color` caches in the element data. If the data have angular expression `{{color.code}}`, then we would have the expression as string. If we use `colorcode="{{color.code}}"` we have calculated value
