### PR TITLE
clean up dom elements

### DIFF
--- a/js/bootstrap-colorpicker-module.js
+++ b/js/bootstrap-colorpicker-module.js
@@ -31,6 +31,11 @@ angular.module('colorpicker.module', [])
         var thisFormat = helper.prepareValues(attrs.colorpicker);
 
         element.colorpicker({format: thisFormat.name});
+        // clean up added elements on scope destruction
+        scope.$on('$destroy', function(){
+          element.data('colorpicker').picker.remove();
+        });
+
         if(!ngModel) return;
 
         element.colorpicker().on('changeColor', function(event) {

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -1,8 +1,10 @@
 files = [
   JASMINE,
   JASMINE_ADAPTER,
+  'http://code.jquery.com/jquery-1.10.1.min.js',
   'libs/angular.min.js',
   'libs/angular-mocks.js',
+  '../lib/bootstrap-colorpicker.js',
   '../js/**/*.js',
   'unit/**/*.js'
 ];

--- a/test/unit/colorpickerSpec.js
+++ b/test/unit/colorpickerSpec.js
@@ -49,5 +49,26 @@ describe('colorpicker module', function () {
       expect(element.val()).toEqual('#ff0000');
       expect(element.data('colorpicker').color.setColor).toHaveBeenCalledWith('#ff0000');
     });
+
+  });
+
+  describe('directive', function () {
+    var $compile, $rootScope;
+    beforeEach(inject(
+      ['$compile','$rootScope', function($c, $r) {
+        $compile = $c;
+        $rootScope = $r;
+      }]
+    ));
+
+    it('should clean up element from dom', function () {
+      var scope = $rootScope.$new();
+      var element = $compile('<input type="text" value="" data-colorpicker />')(scope);
+
+      expect($(document).find('.colorpicker').length).toBe(1);
+      scope.$destroy();
+      expect($(document).find('.colorpicker').length).toBe(0);
+    });
+
   });
 });


### PR DESCRIPTION
bootstrap colorpicker add some hidden elements at the root of the DOM tree. 

When using dynamically added and removed colorpickers, it ends up with lot of ghost elements that may slow down browsers. This patch remove them on scope destruction (event associated with the destruction of any page subtree). 
