### PR TITLE
Optional input field in color picker

### DIFF
--- a/css/colorpicker.css
+++ b/css/colorpicker.css
@@ -151,10 +151,18 @@
 }
 .colorpicker-color {
   height: 10px;
+  margin-bottom: 3px;
   margin-top: 5px;
   clear: both;
   background-position: 0 100%;
 }
 .colorpicker-color div {
   height: 10px;
+}
+.colorpicker input {
+  width: 100px;
+  font-family: arial;
+  font-size: 11px;
+  color: #000;
+  background-color: #fff;
 }

--- a/js/bootstrap-colorpicker-module.js
+++ b/js/bootstrap-colorpicker-module.js
@@ -211,13 +211,22 @@ angular.module('colorpicker.module', [])
       restrict: 'A',
       link: function ($scope, elem, attrs, ngModel) {
 
+        // config
+        var thisFormat = attrs.colorpicker ? attrs.colorpicker : 'hex';
+        var position = attrs.colorpickerPosition ? attrs.colorpickerPosition : 'bottom';
+        var fixedPosition = attrs.colorpickerFixedPosition ? attrs.colorpickerFixedPosition : false;
+        var target = fixedPosition && attrs.colorpickerParent ? elem.parent() : angular.element(document.body);
+        var withInput = attrs.colorpickerWithInput ? attrs.colorpickerWithInput : false;
+
         var
+          inputTemplate = withInput ? '<input type="text" name="colorpicker-input">' : '',
           template = '<div class="colorpicker dropdown">' +
             '<ul class="dropdown-menu">' +
             '<li class="colorpicker-saturation"><i></i></li>' +
             '<li class="colorpicker-hue"><i></i></li>' +
             '<li class="colorpicker-alpha"><i></i></li>' +
             '<li class="colorpicker-color"><div></div></li>' +
+            inputTemplate +
             '<button class="close close-colorpicker">&times;</button>' +
             '</ul>' +
             '</div>',
@@ -227,13 +236,10 @@ angular.module('colorpicker.module', [])
           pickerColorAlpha,
           pickerColorBase,
           pickerColorPointers,
+          pickerColorInput,
           pointer = null,
           slider = null;
 
-        var thisFormat = attrs.colorpicker ? attrs.colorpicker : 'hex';
-        var position = attrs.colorpickerPosition ? attrs.colorpickerPosition : 'bottom';
-        var fixedPosition = attrs.colorpickerFixedPosition ? attrs.colorpickerFixedPosition : false;
-        var target = fixedPosition && attrs.colorpickerParent ? elem.parent() : angular.element(document.body);
 
         $compile(colorpickerTemplate)($scope);
 
@@ -271,6 +277,7 @@ angular.module('colorpicker.module', [])
         pickerColorBase = colorpickerTemplate.find('li')[0].style;
         pickerColorPreview = colorpickerTemplate.find('div')[0].style;
         pickerColorPointers = colorpickerTemplate.find('i');
+        pickerColorInput = colorpickerTemplate.find('input');
 
         var previewColor = function () {
           try {
@@ -361,6 +368,7 @@ angular.module('colorpicker.module', [])
           previewColor();
           var newColor = pickerColor[thisFormat]();
           elem.val(newColor);
+          pickerColorInput.val(newColor);
           if(ngModel) {
             $scope.$apply(ngModel.$setViewValue(newColor));
           }
@@ -427,6 +435,24 @@ angular.module('colorpicker.module', [])
           event.preventDefault();
         });
 
+        pickerColorInput.bind('mousedown', function() {
+          event.stopPropagation();
+        });
+
+        elem.bind('keyup', function() {
+          pickerColorInput.val(elem.val());
+        });
+
+        pickerColorInput.bind('keyup', function(event) {
+          var newColor = this.value;
+          elem.val(newColor);
+          if(ngModel) {
+            $scope.$apply(ngModel.$setViewValue(newColor));
+          }
+          event.stopPropagation();
+          event.preventDefault();
+        });
+
         colorpickerTemplate.find('li').bind('click', function (event) {
           slidersUpdate(event);
           mousemove(event);
@@ -454,3 +480,4 @@ angular.module('colorpicker.module', [])
       }
     };
   }]);
+

--- a/test/unit/colorpickerSpec.js
+++ b/test/unit/colorpickerSpec.js
@@ -52,6 +52,31 @@ describe('colorpicker module', function () {
       expect($(elm).parent().find('.colorpicker').length > 0);
     });
 
+    it('should update the color preview, when putting a new color in the optional input field', function() {
+      var elm = compileElement('<input colorpicker colorpicker-with-input="true" colorpicker-fixed-position="true" ng-model="picker.color" type="text" value="" />', $scope);
+      var $colorPicker = $('.colorpicker:last');
+      var $colorPickerInput = $colorPicker.find('input').val('#ff00ff');
+      var $colorPickerPreview = $colorPicker.find('.colorpicker-color div');
+      $colorPickerInput.trigger('keyup');
+      expect($colorPickerPreview.css('background-color')).toBe('rgb(255, 0, 255)');
+    });
+
+    it('should update the element, when putting a new color in the optional input field', function() {
+      var elm = compileElement('<input colorpicker colorpicker-with-input="true" colorpicker-fixed-position="true" ng-model="picker.color" type="text" value="" />', $scope);
+      var $colorPicker = $('.colorpicker:last');
+      var $colorPickerInput = $colorPicker.find('input').val('#ff00ff');
+      $colorPickerInput.trigger('keyup');
+      expect(elm.val()).toBe('#ff00ff');
+    });
+
+    it('should update the optional input field, when selecting a new color with the slider', function() {
+      var elm = compileElement('<input class="uschi" colorpicker colorpicker-with-input="true" colorpicker-fixed-position="true" ng-model="picker.color" type="text" value="sdf" />', $scope);
+      var $colorPicker = $('.colorpicker:last');
+      var $colorPickerInput = $colorPicker.find('input');
+      elm.val('#333');
+      elm.trigger('keyup');
+      expect($colorPickerInput.val()).toBe('#333');
+    });
   });
 
   describe('Color', function () {


### PR DESCRIPTION
Our users would love to insert their personal color-code within the colorpicker.

We have added an optional input field. It is configurable via the attribute colorpicker-with-input="true".
Changes in the input field cause an update in the colorSlider, the colorPreview, the scope and the element, which opens the colorPicker. On the other way round scope-updates trigger value-updates in the new input field.

It is tested with 3 new tests.
