### PR TITLE
Unregister global mousedown event and optionally emit event that the color picker was hided

### DIFF
--- a/js/bootstrap-colorpicker-module.js
+++ b/js/bootstrap-colorpicker-module.js
@@ -457,11 +457,18 @@ angular.module('colorpicker.module', [])
             };
           };
 
+          var documentMousedownHandler = function() {
+            hideColorpickerTemplate();
+          };
+
           elem.on('click', function () {
             update();
             colorpickerTemplate
                 .addClass('colorpicker-visible')
                 .css(getColorpickerTemplatePosition());
+
+            // register global mousedown event to hide the colorpicker
+            $document.on('mousedown', documentMousedownHandler);
           });
 
           colorpickerTemplate.on('mousedown', function (event) {
@@ -472,14 +479,13 @@ angular.module('colorpicker.module', [])
           var hideColorpickerTemplate = function() {
             if (colorpickerTemplate.hasClass('colorpicker-visible')) {
               colorpickerTemplate.removeClass('colorpicker-visible');
+
+              // unregister the global mousedown event
+              $document.off('mousedown', documentMousedownHandler);
             }
           };
 
           colorpickerTemplate.find('button').on('click', function () {
-            hideColorpickerTemplate();
-          });
-
-          $document.on('mousedown', function () {
             hideColorpickerTemplate();
           });
         }


### PR DESCRIPTION
The unregister of the $document 'mousedown' event prevents that on every click in the document the event handler is triggered, even when the color picker is not visible.

The optional emit event is for cases when you do not want to watch the ng-model for changes. We have for example an array with a lot of items an each item contains a color picker. So the you would have to watch the whole array for changes of the color and that is a bit expensive.
