### PR TITLE
Created a variable for the base path

### DIFF
--- a/less/colorpicker.less
+++ b/less/colorpicker.less
@@ -1,3 +1,5 @@
+@colorpicker-path: '..';
+
 .colorpicker-visible,
 .colorpicker-visible .dropdown-menu {
   display: block !important;
@@ -7,7 +9,7 @@ colorpicker-saturation {
   display: block;
   width: 100px;
   height: 100px;
-  background-image: data-uri('../img/saturation.png');
+  background-image: data-uri('@{colorpicker-path}/img/saturation.png');
   cursor: crosshair;
   float: left;
   i {
@@ -53,7 +55,7 @@ colorpicker-alpha {
 }
 
 colorpicker-hue {
-  background-image: data-uri('../img/hue.png');
+  background-image: data-uri('@{colorpicker-path}/img/hue.png');
 }
 
 colorpicker-alpha {
@@ -62,7 +64,7 @@ colorpicker-alpha {
 
 colorpicker-alpha,
 .colorpicker-color {
-  background-image: data-uri('../img/alpha.png');
+  background-image: data-uri('@{colorpicker-path}/img/alpha.png');
 }
 
 .colorpicker {


### PR DESCRIPTION
I installed the colorpicker with bower and tried to import the less file into my existing less project.
The problem with that is that the image files are not found anymore. 

By moving the base path to a variable it becomes possible to override it in another less file from outside:

``` css
@colorpicker-path: '../../../bower_components/angular-bootstrap-colorpicker';
```
