### PR TITLE
Add a colorpicker-is-open attribute for controlling the visibility of the popover

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ The color picker in UI Bootstrap modal (the parent element position property mus
 <input colorpicker colorpicker-parent="true" type="text" ng-model="your_model" />
 ```
 
-Controlling the visibility of the color picker
+Binding the visibility of the color picker to a variable in the scope
 ```html
-<input colorpicker colorpicker-is-open="isOpen" type="text" ng-model="your_model" ng-change="isOpen = false" />
+<input colorpicker colorpicker-is-open="isOpen" type="text" ng-model="your_model" />
+```
+
+Auto hiding the color picker when a color has been selected
+```html
+<input colorpicker colorpicker-close-on-select type="text" ng-model="your_model" />
+```

--- a/README.md
+++ b/README.md
@@ -68,3 +68,7 @@ The color picker in UI Bootstrap modal (the parent element position property mus
 ```html
 <input colorpicker colorpicker-parent="true" type="text" ng-model="your_model" />
 ```
+
+Controlling the visibility of the color picker
+```html
+<input colorpicker colorpicker-is-open="isOpen" type="text" ng-model="your_model" ng-change="isOpen = false" />

--- a/js/bootstrap-colorpicker-module.js
+++ b/js/bootstrap-colorpicker-module.js
@@ -345,6 +345,9 @@ angular.module('colorpicker.module', [])
               .on('click', function(event) {
                 Slider.setSaturation(event, fixedPosition);
                 mousemove(event);
+                if (angular.isDefined(attrs.colorpickerCloseOnSelect)) {
+                  hideColorpickerTemplate();
+                }
               })
               .on('mousedown', function(event) {
                 Slider.setSaturation(event, fixedPosition);
@@ -485,6 +488,9 @@ angular.module('colorpicker.module', [])
 
               if (attrs.colorpickerIsOpen) {
                 $scope[attrs.colorpickerIsOpen] = true;
+                if (!$scope.$$phase) {
+                  $scope.$digest(); //trigger the watcher to fire
+                }
               }
             }
 
@@ -519,6 +525,9 @@ angular.module('colorpicker.module', [])
 
               if (attrs.colorpickerIsOpen) {
                 $scope[attrs.colorpickerIsOpen] = false;
+                if (!$scope.$$phase) {
+                  $scope.$digest(); //trigger the watcher to fire
+                }
               }
             }
           };

--- a/js/bootstrap-colorpicker-module.js
+++ b/js/bootstrap-colorpicker-module.js
@@ -470,21 +470,30 @@ angular.module('colorpicker.module', [])
             hideColorpickerTemplate();
           };
 
-          if(inline === false) { 
-            elem.on('click', function () {
+          var showColorpickerTemplate = function() {
+
+            if (!colorpickerTemplate.hasClass('colorpicker-visible')) {
               update();
               colorpickerTemplate
                 .addClass('colorpicker-visible')
                 .css(getColorpickerTemplatePosition());
 
-              // register global mousedown event to hide the colorpicker
-              $document.on('mousedown', documentMousedownHandler);
-            });
+              if (inline === false) {
+                // register global mousedown event to hide the colorpicker
+                $document.on('mousedown', documentMousedownHandler);
+              }
+
+              if (attrs.colorpickerIsOpen) {
+                $scope[attrs.colorpickerIsOpen] = true;
+              }
+            }
+
+          };
+
+          if(inline === false) { 
+            elem.on('click', showColorpickerTemplate);
           } else {
-            update();
-            colorpickerTemplate
-              .addClass('colorpicker-visible')
-              .css(getColorpickerTemplatePosition());
+            showColorpickerTemplate();
           }
 
           colorpickerTemplate.on('mousedown', function (event) {
@@ -507,12 +516,29 @@ angular.module('colorpicker.module', [])
               emitEvent('colorpicker-closed');
               // unregister the global mousedown event
               $document.off('mousedown', documentMousedownHandler);
+
+              if (attrs.colorpickerIsOpen) {
+                $scope[attrs.colorpickerIsOpen] = false;
+              }
             }
           };
 
           colorpickerTemplate.find('button').on('click', function () {
             hideColorpickerTemplate();
           });
+
+          if (attrs.colorpickerIsOpen) {
+            $scope.$watch(attrs.colorpickerIsOpen, function(shouldBeOpen) {
+
+              if (shouldBeOpen === true) {
+                showColorpickerTemplate();
+              } else if (shouldBeOpen === false) {
+                hideColorpickerTemplate();
+              }
+
+            });
+          }
+
         }
       };
     }]);


### PR DESCRIPTION
Continuing on from https://github.com/buberdds/angular-bootstrap-colorpicker/issues/66 here's my implementation. I tried to include a unit test but I couldn't get your tests to run. It kept giving me the error:
```
TypeError: Cannot read property '$injector' of undefined
	    at Object.workFn (/Users/mattlewis/Sites/angular-bootstrap-colorpicker/test/libs/angular-mocks.js:1698:15)
TypeError: Cannot read property '$modules' of undefined
	    at Object.workFn (/Users/mattlewis/Sites/angular-bootstrap-colorpicker/test/libs/angular-mocks.js:1769:25)
TypeError: Cannot read property 'setKnob' of undefined
	    at Object.<anonymous> (/Users/mattlewis/Sites/angular-bootstrap-colorpicker/test/unit/colorpickerSpec.js:166:13)
TypeError: Cannot read property '$injector' of undefined
	    at Object.<anonymous> (/Users/mattlewis/Sites/angular-bootstrap-colorpicker/test/libs/angular-mocks.js:1641:24)"
```

Any ideas?