### PR TITLE
Open/close colorpicker programmatically #137

### DIFF
--- a/js/bootstrap-colorpicker-module.js
+++ b/js/bootstrap-colorpicker-module.js
@@ -522,7 +522,7 @@ angular.module('colorpicker.module', [])
 
               if (attrs.colorpickerIsOpen) {
                 $scope[attrs.colorpickerIsOpen] = true;
-                if (!$scope.$$phase) {
+                if (!$scope.$$phase || !$scope.$root.$$phase) {
                   $scope.$digest(); //trigger the watcher to fire
                 }
               }
@@ -558,7 +558,7 @@ angular.module('colorpicker.module', [])
 
               if (attrs.colorpickerIsOpen) {
                 $scope[attrs.colorpickerIsOpen] = false;
-                if (!$scope.$$phase) {
+                if (!$scope.$$phase || !$scope.$root.$$phase) {
                   $scope.$digest(); //trigger the watcher to fire
                 }
               }


### PR DESCRIPTION
When the colorpicker is nested in another directive, we get a digest error from the library (even using $timeout).

scope.$digest could be removed, because it is seems not necessary (l.526 and l.562), as colorpickerTemplate is already an angular element, it should be already handled by angular cycle (and it worked for me by removing it).

But just in case it is of some use and I didn't figure it out, I preferred to add a check on the parent directive cycle status instead of removing it.

Thanks.
Remy.