### PR TITLE
Fixed memory leak

### DIFF
--- a/js/bootstrap-colorpicker-module.js
+++ b/js/bootstrap-colorpicker-module.js
@@ -406,6 +406,10 @@ angular.module('colorpicker.module', [])
           elem.on('$destroy', function() {
             colorpickerTemplate.remove();
           });
+          
+          $scope.$on('$destroy', function () {
+            colorpickerTemplate.remove();
+          });
 
           function previewColor() {
             try {


### PR DESCRIPTION
Leak happens on project where we detach HTML elements from controller before it is destroyed and elem.on('$destroy'...) is not called, but $scope.on('$destroy'...) works